### PR TITLE
1.5.2 Release update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
 
+#eclipse
 .classpath
 .project
 bin/
 *.prefs
+
+#gradle
+.gradle/
+*.gradle
+gradlew
+gradlew.*

--- a/bake/bakeMetrics.php
+++ b/bake/bakeMetrics.php
@@ -8,7 +8,7 @@
  	<meta name="keywords" content="Geolykt, Minecraft, Bake, Metrics, why are you here">
  	<meta name="author" content="Geolykt">
 </head>
-<body><p>$1.5.1$1.5.1$<br> Most recent nightly version / Most recent public version <br> To see the version usage use <a href="versions.txt">this file</a></p> 
+<body><p>$1.5.2$1.5.2$<br> Most recent nightly version / Most recent public version <br> To see the version usage use <a href="versions.txt">this file</a></p> 
  <?php
  #handle versiuon submittion
  if (count($_GET) == 0) {

--- a/bake/src/de/geolykt/bake/Bake_Auxillary.java
+++ b/bake/src/de/geolykt/bake/Bake_Auxillary.java
@@ -13,13 +13,13 @@ public class Bake_Auxillary {
 	 * The version of the plugin in the MAJOR.MINOR.PATCH format.
 	 * @since 1.4.1, public since 1.5.1
 	 */
-	public static final String PLUGIN_VERSION = "1.5.1";
+	public static final String PLUGIN_VERSION = "1.5.2";
 	
 	/**
 	 * The version of the plugin in the format used by the bakeMetrics software.
 	 * @since 1.5.1
 	 */
-	public static final byte PLUGIN_VERSION_ID = 0x1;
+	public static final byte PLUGIN_VERSION_ID = 0x2;
 	
 	/**
 	 * This function is in place to make it more easy for the plugin to parse the config file from an older version (config version 2) to a newer (config version 3+).
@@ -63,7 +63,9 @@ public class Bake_Auxillary {
 	}
 	
 	/**
-	 * returns the length of the longest String in an array
+	 * returns the length of the longest String in an array.
+	 * @deprecated Not used and thus not tested in recent versions. Will be used for 1.6 (hopefully)
+	 * TODO Use this
 	 * 
 	 * @param s Array of strings to be looked for
 	 * @return The length of the longest String in the array

--- a/bake/src/de/geolykt/bake/util/EnchantmentLib.java
+++ b/bake/src/de/geolykt/bake/util/EnchantmentLib.java
@@ -1,7 +1,5 @@
 package de.geolykt.bake.util;
 
-import org.bukkit.Bukkit;
-
 /**
  * An enchantment name conversion library written for the bake plugin.
  * @author Geolykt

--- a/bake/src/de/geolykt/bake/util/EnchantmentLib.java
+++ b/bake/src/de/geolykt/bake/util/EnchantmentLib.java
@@ -1,0 +1,128 @@
+package de.geolykt.bake.util;
+
+import org.bukkit.Bukkit;
+
+/**
+ * An enchantment name conversion library written for the bake plugin.
+ * @author Geolykt
+ * @since 1.5.2
+ */
+public class EnchantmentLib {
+
+	/**
+	 *  Converts the input string, if applicable, from a 1.12 (or earlier) compatible string to a 1.13 (or later) compatible string.
+	 *  May not be 100% accurate, needs testing.
+	 */
+	public static String Convert12to13 (String enchant) {
+		enchant = enchant.toUpperCase();
+		
+		//ARMOR ENCHANTS
+		enchant = enchant.replaceAll("PROTECTION_ENVIRONMENTAL", "protection");
+		enchant = enchant.replaceAll("PROTECTION_FIRE", "fire_protection");
+		enchant = enchant.replaceAll("PROTECTION_FALL", "feather_falling");
+		enchant = enchant.replaceAll("PROTECTION_EXPLOSIONS", "blast_protection");
+		enchant = enchant.replaceAll("PROTECTION_PROJECTILE", "projectile_protection");
+		enchant = enchant.replaceAll("OXYGEN", "respiration");
+		enchant = enchant.replaceAll("WATER_WORKER", "aqua_affinity");
+		enchant = enchant.replaceAll("THORNS", "thorns");
+		enchant = enchant.replaceAll("DEPTH_STRIDER", "depth_strider");
+		enchant = enchant.replaceAll("FROST_WALKER", "frost_walker");
+		
+		//TOOL ENCHANTS
+		enchant = enchant.replaceAll("DAMAGE_ALL", "sharpness");
+		enchant = enchant.replaceAll("DAMAGE_UNDEAD", "smite");
+		enchant = enchant.replaceAll("DAMAGE_ARTHROPODS", "bane_of_arthropods");
+		enchant = enchant.replaceAll("KNOCKBACK", "knockback");
+		enchant = enchant.replaceAll("FIRE_ASPECT", "fire_aspect");
+		enchant = enchant.replaceAll("LOOT_BONUS_MOBS", "looting");
+		enchant = enchant.replaceAll("DIG_SPEED", "efficiency");
+		enchant = enchant.replaceAll("SILK_TOUCH", "silk_touch");
+		enchant = enchant.replaceAll("DURABILITY", "unbreaking");
+		enchant = enchant.replaceAll("LOOT_BONUS_BLOCKS", "fortune");
+		enchant = enchant.replaceAll("SWEEPING_EDGE", "sweeping");
+		
+		//(CROSS-)BOW ENCHANTS
+		enchant = enchant.replaceAll("ARROW_DAMAGE", "power");
+		enchant = enchant.replaceAll("ARROW_KNOCKBACK", "punch");
+		enchant = enchant.replaceAll("ARROW_FIRE", "flame");
+		enchant = enchant.replaceAll("ARROW_INFINITE", "infinity");
+		enchant = enchant.replaceAll("MULTISHOT", "multishot");
+		enchant = enchant.replaceAll("QUICK_CHARGE", "quick_charge");
+		enchant = enchant.replaceAll("PIERCING", "piercing");
+		
+		//FISHING ENCHANTS
+		enchant = enchant.replaceAll("LUCK", "luck_of_the_sea");
+		enchant = enchant.replaceAll("LURE", "lure");
+		
+		//TRIDENT ENCHANTS
+		enchant = enchant.replaceAll("LOYALTY", "loyalty");
+		enchant = enchant.replaceAll("IMPALING", "impaling");
+		enchant = enchant.replaceAll("CHANNELING", "channeling");
+		enchant = enchant.replaceAll("RIPTIDE", "riptide");
+		
+		//MISC
+		enchant = enchant.replaceAll("MENDING", "mending");
+		enchant = enchant.replaceAll("BINDING_CURSE", "binding_curse");
+		enchant = enchant.replaceAll("VANISHING_CURSE", "vanishing_curse");
+		return enchant;
+	}
+	
+
+	/**
+	 *  Converts the input string, if applicable, from a 1.13 (or earlier) compatible string to a 1.12 (or later) compatible string.
+	 *  May not be 100% accurate, needs testing.
+	 */
+	public static String Convert13to12 (String enchant) {
+		enchant = enchant.toLowerCase();
+		
+		//ARMOR ENCHANTS
+		enchant = enchant.replaceAll("protection", "PROTECTION_ENVIRONMENTAL");
+		enchant = enchant.replaceAll("fire_protection", "PROTECTION_FIRE");
+		enchant = enchant.replaceAll("feather_falling", "PROTECTION_FALL");
+		enchant = enchant.replaceAll("blast_protection", "PROTECTION_EXPLOSIONS");
+		enchant = enchant.replaceAll("projectile_protection", "PROTECTION_PROJECTILE");
+		enchant = enchant.replaceAll("respiration", "OXYGEN");
+		enchant = enchant.replaceAll("aqua_affinity", "WATER_WORKER");
+		enchant = enchant.replaceAll("thorns", "THORNS");
+		enchant = enchant.replaceAll("depth_strider", "DEPTH_STRIDER");
+		enchant = enchant.replaceAll("frost_walker", "FROST_WALKER");
+		
+		//TOOL ENCHANTS
+		enchant = enchant.replaceAll("sharpness", "DAMAGE_ALL");
+		enchant = enchant.replaceAll("smite", "DAMAGE_UNDEAD");
+		enchant = enchant.replaceAll("bane_of_arthropods", "DAMAGE_ARTHROPODS");
+		enchant = enchant.replaceAll("knockback", "KNOCKBACK");
+		enchant = enchant.replaceAll("fire_aspect", "FIRE_ASPECT");
+		enchant = enchant.replaceAll("looting", "LOOT_BONUS_MOBS");
+		enchant = enchant.replaceAll("efficiency", "DIG_SPEED");
+		enchant = enchant.replaceAll("silk_touch", "SILK_TOUCH");
+		enchant = enchant.replaceAll("unbreaking", "DURABILITY");
+		enchant = enchant.replaceAll("fortune", "LOOT_BONUS_BLOCKS");
+		enchant = enchant.replaceAll("sweeping", "SWEEPING_EDGE");
+		
+		//(CROSS-)BOW ENCHANTS
+		enchant = enchant.replaceAll("power", "ARROW_DAMAGE");
+		enchant = enchant.replaceAll("punch", "ARROW_KNOCKBACK");
+		enchant = enchant.replaceAll("flame", "ARROW_FIRE");
+		enchant = enchant.replaceAll("infinity", "ARROW_INFINITE");
+		enchant = enchant.replaceAll("multishot", "MULTISHOT");
+		enchant = enchant.replaceAll("quick_charge", "QUICK_CHARGE");
+		enchant = enchant.replaceAll("piercing", "PIERCING");
+		
+		//FISHING ENCHANTS
+		enchant = enchant.replaceAll("luck_of_the_sea", "LUCK");
+		enchant = enchant.replaceAll("lure", "LURE");
+		
+		//TRIDENT ENCHANTS
+		enchant = enchant.replaceAll("loyalty", "LOYALTY");
+		enchant = enchant.replaceAll("impaling", "IMPALING");
+		enchant = enchant.replaceAll("channeling", "CHANNELING");
+		enchant = enchant.replaceAll("riptide", "RIPTIDE");
+		
+		//MISC
+		enchant = enchant.replaceAll("mending", "MENDING");
+		enchant = enchant.replaceAll("binding_curse", "BINDING_CURSE");
+		enchant = enchant.replaceAll("vanishing_curse", "VANISHING_CURSE");
+		return enchant;
+	}
+}

--- a/config.yml
+++ b/config.yml
@@ -13,6 +13,8 @@ bake:
     noMeddle: false
     #leave it be, setting it to false will break almost everything
     cnfgStore: true
+    #Should enchants get automatically converted (might fix bugs connected to enchants, but can cause longer starting times.)
+    doEnchantConvert: true
     #should a broadcast be done when the day's record is broken?
     doRecordSurpassBroadcast: true
   #amount of required wheat
@@ -21,6 +23,8 @@ bake:
     #set this to false if you don't want bake to contact https://geolykt.de/src/bake/bakeMetrics.php
     opt-out: false
   award:
+    #amount of vault money that should be given to each participant on completion.
+    money: 100
     #maximum amount of things that can be rewarded, so if it is set to 1 only 1 itemstack will be given out, however it can also award less.
     maximum: 3
     #the slot talked before will come handy here, please mind that it starts with 0 and ends with n - 1
@@ -57,7 +61,6 @@ bake:
       '1': §cYUMMY!
       '2': §eShiny!
   enchantment:
-    #!!!!!!!!!!IMPORTANT!!!!!! THESE VALUES WON'T WORK PER DEFAULT ON 1.12 AND EARLIER!!!!!!!!!!!!!! This may get changed with 1.6. but it may as well not change
     slot:
       '0': UNBREAKING@5
       '1': UNBREAKING@5|MENDING@1

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,8 +1,9 @@
 name: bake
 main: de.geolykt.bake.Bake
-version: 1.5.1
+version: 1.5.2
 author: Geolykt
 api-version: 1.15
+softdepend: [Vault] #Vault for money stuff
 website: www.geolykt.de
 commands:
   bake:


### PR DESCRIPTION
-Automatic update checks
-Added vault support
-Added config parameter "bake.award.money", which controls how much money should be rewarded.
-Enchantment conversion between 1.12 ench names and 1.13 ench names. (no need for more pain!)
-Added config parameter "bake.general.doEnchantConvert" allowing or disallowing feature mentioned above.
-Fixed that the "%RECORD%" placeholder would show the invalid date (the date on which the record was broken, not the date where the record was actually done.)
